### PR TITLE
fix compilation error

### DIFF
--- a/src/MD_AD9833.cpp
+++ b/src/MD_AD9833.cpp
@@ -254,7 +254,7 @@ boolean MD_AD9833::setFrequency(channel_t chan, float freq)
   // Now send the two parts of the frequency 14 bits at a time,
   // LSBs first
   spiSend(freq_select | (uint16_t)((uint32_t)_regFreq[chan] & 0x3fff));
-  spiSend(freq_select | (uint16_t)((uint32_t)_regFreq[chan] >> 14) & 0x3fff));
+  spiSend(freq_select | (uint16_t)(((uint32_t)_regFreq[chan] >> 14) & 0x3fff));
 
   return(true);
 }


### PR DESCRIPTION
Fix compilation error due to unbalanced braces in : 

MD_AD9833.cpp: In member function 'boolean MD_AD9833::setFrequency(MD_AD9833::channel_t, float)':
MD_AD9833.cpp:257:77: error: expected ';' before ')' token
spiSend(freq_select | (uint16_t)((uint32_t)_regFreq[chan] >> 14) & 0x3fff));